### PR TITLE
Add autocomplete + readme example for "distinct" (cleanups for issue #60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ As an example, this is the `commits` table:
 * `select hash, message, author_email from commits where author = 'cloudson'`
 * `select date, message from commits where date < '2014-04-10'`
 * `select message from commits where 'hell' in message order by date asc`
+* `select distinct author from commits where date < '2020-01-01'`
 
 ## Questions?
 

--- a/autocomplete.go
+++ b/autocomplete.go
@@ -26,6 +26,7 @@ func suggestLatest(focused string, candidacies [][]string) [][]rune {
 func containColumns(focused string) bool {
 	_, ok := isContained(focused, []string{
 		"select", // gitql> select [tab
+		"distinct,",
 		"name,",
 		"url,",
 		"push_url,",
@@ -72,6 +73,7 @@ func suggestQuery(inputs [][]rune, pos int) [][]rune {
 		// gitql> select [tab
 		// In the case where the most recent input is "select"
 		return [][]rune{
+			[]rune("distinct"),
 			[]rune("*"),
 			[]rune("name"),
 			[]rune("url"),

--- a/autocomplete_test.go
+++ b/autocomplete_test.go
@@ -109,6 +109,7 @@ func TestSuggestQuery(t *testing.T) {
 		[]rune(""),
 	}
 	assertSuggestsQuery(t, pattern2, []string{
+		"distinct",
 		"*",
 		"name",
 		"url",

--- a/lexical/lexical_test.go
+++ b/lexical/lexical_test.go
@@ -135,29 +135,11 @@ func TestReservedWords(t *testing.T) {
 
 	var token uint8
 
-	token, _ = Token()
-	assertToken(t, token, T_SELECT)
-
-	token, _ = Token()
-	assertToken(t, token, T_DISTINCT)
-
-	token, _ = Token()
-	assertToken(t, token, T_FROM)
-
-	token, _ = Token()
-	assertToken(t, token, T_WHERE)
-
-	token, _ = Token()
-	assertToken(t, token, T_IN)
-
-	token, _ = Token()
-	assertToken(t, token, T_NOT)
-
-	token, _ = Token()
-	assertToken(t, token, T_COUNT)
-
-	token, _ = Token()
-	assertToken(t, token, T_EOF)
+	tokens := []uint8{T_SELECT, T_DISTINCT, T_FROM, T_WHERE, T_IN, T_NOT, T_COUNT, T_EOF}
+	for i := range tokens {
+		token, _ = Token()
+		assertToken(t, token, tokens[i])
+	}
 }
 
 func TestNotReservedWords(t *testing.T) {

--- a/semantical/semantical_test.go
+++ b/semantical/semantical_test.go
@@ -129,7 +129,14 @@ func TestSmallerWithDateWithoutTime(t *testing.T) {
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
+}
 
+func TestRepeatedDistinct(t *testing.T) {
+	parser.New("select distinct distinct author from commits")
+	_, parserErr := parser.AST()
+	if parserErr == nil {
+		t.Fatalf(parserErr.Error())
+	}
 }
 
 // You should not test stupid things like "c" in "cloudson" or 1 = 1 ¬¬


### PR DESCRIPTION
UPDATE: I remade this PR into a cleanup, since the core implementation was better taken care of in another PR.

I'm taking a look at issue #60 and I think I got the easy bits done:
- add "distinct" in autocompletion + test
- ~add "distinct" in lexer~
- ~add "distinct" in parser and remember it as a boolean, similar to how `count(*)` works. Only added a minimal failing test for easy of development.~

Is this more or less the right direction?
Is the next step somewhere in `visitor` to prevent duplicates in the output data rows. Probably first implementation would just have a `map` and maybe warn if its `.size` grows beyond a couple hundred uniques.

If someone has time to spare, I'd be very happy for some guidance :). I know SQL by heart and some git plumbing and porcelain, but am very fresh in golang. I'm thinking of later using gitql to revive some painfully outdated/slow variations of the olden golden gitstats packages.