### PR TITLE
Fix ci warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,12 @@ jobs:
 
   build-mac:
     name: Build mac
-    runs-on: macOS-10.14
+    runs-on: macOS-10.15
     steps:
     - name: Set up Go 1.12
       uses: actions/setup-go@v1
       with:
-        version: 1.12
+        go-version: 1.12
       id: go
 
     - name: Check out code into the Go module directory
@@ -72,7 +72,7 @@ jobs:
     - name: Set up Go 1.12
       uses: actions/setup-go@v1
       with:
-        version: 1.12
+        go-version: 1.12
       id: go
 
     - name: Check out code into the Go module directory

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 git2go
 libgit2
 gitql
+.DS_Store
 .vscode*
 .idea/
 vendor

--- a/README.md
+++ b/README.md
@@ -17,14 +17,13 @@ See more [here](https://asciinema.org/a/97094)
 
 ## How to install
 
-You can access the [releases page](https://github.com/cloudson/gitql/releases) and just grab the binary. If you want to compile itself just run `go build .`. 
+You can access the [releases page](https://github.com/cloudson/gitql/releases) and just grab the binary. If you want to compile itself just run `go build .`.
 
-## Examples 
+## Examples
 
-`gitql "your query" `   
-or   
+`gitql "your query" `  
+or  
 `git ql "your query" `
-
 
 As an example, this is the `commits` table:
 
@@ -42,10 +41,10 @@ As an example, this is the `commits` table:
 (see more tables [here](tables.md))
 
 ## Example Commands
-* `select hash, author, message from commits limit 3`  
-* `select hash, message from commits where 'hell' in full_message or 'Fuck' in full_message`  
-* `select hash, message, author_email from commits where author = 'cloudson'`  
-* `select date, message from commits where date < '2014-04-10' `  
+* `select hash, author, message from commits limit 3`
+* `select hash, message from commits where 'hell' in full_message or 'Fuck' in full_message`
+* `select hash, message, author_email from commits where author = 'cloudson'`
+* `select date, message from commits where date < '2014-04-10'`
 * `select message from commits where 'hell' in message order by date asc`
 
 ## Questions?


### PR DESCRIPTION
In the github actions pipeline for my previous PR there were some warnings: https://github.com/filhodanuvem/gitql/actions/runs/292115910

This PR attempts to fix those... let's see if the pipeline agrees.

Note: the pipeline suggested macOS-latest, but I saw from the work for preparing 2.0 that Cloudson specifically set a fixed version, so I kept it fixed also in this PR and just changed 10.14 to 10.15.